### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "csharp"
+run = "Mono"

--- a/README-dist.txt
+++ b/README-dist.txt
@@ -1,7 +1,7 @@
 You've downloaded TrueCraft, an open source implementation of Minecraft beta
 1.7.3. Please note that TrueCraft is still experimental, and is likely to
 include bugs and unfinished features.
-
+[![Run on Repl.it](https://repl.it/badge/github/UzayAnil/TrueCraft)](https://repl.it/github/UzayAnil/TrueCraft)
                            === Running TrueCraft ===
 
 On Windows, double click `TrueCraft.Launcher.exe`. This will allow you to play


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).